### PR TITLE
fix: 翻译接口from参数错误

### DIFF
--- a/lark_oapi/api/translation/v1/model/term.py
+++ b/lark_oapi/api/translation/v1/model/term.py
@@ -25,7 +25,7 @@ class TermBuilder(object):
         self._term = Term()
 
     def from_(self, from_: str) -> "TermBuilder":
-        self._term.from_ = from_
+        setattr(self._term, "from", from_)
         return self
 
     def to(self, to: str) -> "TermBuilder":


### PR DESCRIPTION
翻译api参数
{
  "source_language": "zh",
  "text": "尝试使用一下飞书吧",
  "target_language": "en",
  "glossary": [
    {
      "from": "飞书",
      "to": "Lark"
    }
  ]
}

sdk使用from_

采用setattr 修复