### PR TITLE
fix: fixed a typo in GetSubscribeFileResponseBody

### DIFF
--- a/lark_oapi/api/drive/v1/model/get_subscribe_file_response_body.py
+++ b/lark_oapi/api/drive/v1/model/get_subscribe_file_response_body.py
@@ -6,11 +6,11 @@ from lark_oapi.core.construct import init
 
 class GetSubscribeFileResponseBody(object):
     _types = {
-        "is_subseribe": bool,
+        "is_subscribe": bool,
     }
 
     def __init__(self, d=None):
-        self.is_subseribe: Optional[bool] = None
+        self.is_subscribe: Optional[bool] = None
         init(self, d, self._types)
 
     @staticmethod
@@ -22,8 +22,8 @@ class GetSubscribeFileResponseBodyBuilder(object):
     def __init__(self) -> None:
         self._get_subscribe_file_response_body = GetSubscribeFileResponseBody()
 
-    def is_subseribe(self, is_subseribe: bool) -> "GetSubscribeFileResponseBodyBuilder":
-        self._get_subscribe_file_response_body.is_subseribe = is_subseribe
+    def is_subseribe(self, is_subscribe: bool) -> "GetSubscribeFileResponseBodyBuilder":
+        self._get_subscribe_file_response_body.is_subscribe = is_subscribe
         return self
 
     def build(self) -> "GetSubscribeFileResponseBody":


### PR DESCRIPTION
There is a typo in the current code, which doesn't match the description of *Get Docs events subscription status* page in [official document](https://open.feishu.cn/document/server-docs/docs/drive-v1/event/subscribe)
A rough testing coded was written, but didn't find proper folder to place it though...
