### PR TITLE
fix: 将 department_id 的类型标注由 int 改为 str

### DIFF
--- a/lark_oapi/api/contact/v3/model/children_department_request.py
+++ b/lark_oapi/api/contact/v3/model/children_department_request.py
@@ -13,7 +13,7 @@ class ChildrenDepartmentRequest(BaseRequest):
         self.fetch_child: Optional[bool] = None
         self.page_size: Optional[int] = None
         self.page_token: Optional[str] = None
-        self.department_id: Optional[int] = None
+        self.department_id: Optional[str] = None
 
     @staticmethod
     def builder() -> "ChildrenDepartmentRequestBuilder":
@@ -54,9 +54,9 @@ class ChildrenDepartmentRequestBuilder(object):
         self._children_department_request.add_query("page_token", page_token)
         return self
 
-    def department_id(self, department_id: int) -> "ChildrenDepartmentRequestBuilder":
+    def department_id(self, department_id: str) -> "ChildrenDepartmentRequestBuilder":
         self._children_department_request.department_id = department_id
-        self._children_department_request.paths["department_id"] = str(department_id)
+        self._children_department_request.paths["department_id"] = department_id
         return self
 
     def build(self) -> ChildrenDepartmentRequest:


### PR DESCRIPTION
关联 issue：https://github.com/larksuite/oapi-sdk-python/issues/100