### PR TITLE
fix: replace deprecated pkg_resources with pkgutil.extend_path

### DIFF
--- a/lark_oapi/ws/pb/google/__init__.py
+++ b/lark_oapi/ws/pb/google/__init__.py
@@ -1,4 +1,1 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
## Problem

The `lark_oapi/ws/pb/google/__init__.py` file triggers a deprecation warning on every import:

```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30.
```

## Solution

Replace `pkg_resources.declare_namespace()` with `pkgutil.extend_path()` directly.

The original code already used `pkgutil.extend_path` as a fallback when `pkg_resources` wasn't installed, so this change is functionally equivalent — just removes the deprecated path entirely.

## Impact

- No behavior change — `pkgutil.extend_path` serves the same namespace package purpose
- Eliminates the deprecation warning for all users on setuptools ≥81
- Future-proofs against `pkg_resources` removal