### PR TITLE
fix: replace deprecated pkg_resources namespace declaration

### DIFF
--- a/lark_oapi/ws/pb/google/__init__.py
+++ b/lark_oapi/ws/pb/google/__init__.py
@@ -1,4 +1,1 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
## Summary

Replace the deprecated `pkg_resources.declare_namespace()` namespace declaration in `lark_oapi/ws/pb/google/__init__.py` with the existing `pkgutil.extend_path()` fallback path.

## Why

Importing this module currently emits:

```text
UserWarning: pkg_resources is deprecated as an API ... Refrain from using this package or pin to Setuptools<81.
```

In newer setuptools environments, this can become a hard import failure when `pkg_resources.declare_namespace` is unavailable.

## Notes

This is the same minimal approach as PR #124, but that PR is currently blocked by CLA because its commit author email is not associated with a GitHub user. Opening this replacement so the fix has an unblocked path to merge.

Fixes #108.
Refs #115.
Refs #124.

## Verification

Ran a minimal import proof with warnings treated as errors:

```bash
python -W error::UserWarning - <<'PY'
import importlib.util
from pathlib import Path
p = Path('lark_oapi/ws/pb/google/__init__.py').resolve()
spec = importlib.util.spec_from_file_location(
    'lark_oapi.ws.pb.google',
    p,
    submodule_search_locations=[str(p.parent)],
)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
assert mod.__path__
print('ok: lark_oapi.ws.pb.google imports without pkg_resources warning')
PY
```