### PR TITLE
feat: support register app addons parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,40 @@ result = lark.register_app(
 print(result["client_id"])
 ```
 
+### Custom scopes/events/callbacks and updating an existing app
+
+When creating an app, use `addons` to incrementally request scopes, event subscriptions,
+and callbacks on top of the platform base template. They are pre-filled into the
+confirm page shown after the user scans the QR code, and take effect once the user
+confirms:
+
+```python
+result = lark.register_app(
+    on_qr_code=on_qr_code,
+    addons={
+        "scopes": {
+            "tenant": ["im:message:send_as_bot"],
+            "user": ["calendar:calendar:read"],
+        },
+        "events": {"items": {"tenant": ["im.message.receive_v1"]}},
+        "callbacks": {"items": ["card.action.trigger"]},
+    },
+    create_only=True,
+)
+
+lark.register_app(
+    on_qr_code=on_qr_code,
+    app_id="cli_xxx",
+    addons={"scopes": {"tenant": ["drive:drive.metadata:readonly"]}},
+)
+```
+
+Notes:
+
+- `addons` is additive only: items are merged on top of the base template; base permissions can never be removed.
+- Only the 5 public config types are supported: tenant/user scopes, tenant/user events, and callbacks. Sensitive config such as event request URLs, `security.*`, or encrypt keys cannot travel through `addons`.
+- The SDK validates the shape, not the item names; names unknown to the platform catalog are ignored by the confirm page.
+
 For a real manual E2E run without mocked registration responses:
 
 ```bash
@@ -96,6 +130,14 @@ python3 samples/registration/app_preset_live_e2e.py --open
 | `app_preset.avatar` | App avatar URL(s). 1-6 URLs supported; the first one is selected by default. Allowed formats are handled by the Web page: png / jpg / jpeg / webp / gif | string or list[string] | No | - |
 | `app_preset.name` | App name. Supports the `{user}` placeholder, replaced by the Web page with the scanning user's name | string | No | - |
 | `app_preset.desc` | App description. Supports the `{user}` placeholder | string | No | - |
+| `addons` | Incremental scopes/events/callbacks pre-filled into the confirm page, effective after user confirmation | dict | No | - |
+| `addons.scopes.tenant` | App-identity scopes, e.g. `im:message:send_as_bot` | list[string] | No | - |
+| `addons.scopes.user` | User-identity scopes, e.g. `calendar:calendar:read` | list[string] | No | - |
+| `addons.events.items.tenant` | App-identity events, e.g. `im.message.receive_v1` | list[string] | No | - |
+| `addons.events.items.user` | User-identity events, e.g. `calendar.calendar.event.changed_v4` | list[string] | No | - |
+| `addons.callbacks.items` | Callbacks, e.g. `card.action.trigger` | list[string] | No | - |
+| `create_only` | When `True`, the landing page only allows creating a new app and hides the select-existing-app entry. Takes precedence over `app_id` when both are set | bool | No | - |
+| `app_id` | App ID (`cli_` prefix) of an existing app. When set, the flow updates that app's config; carried on the QR URL as `clientID` | string | No | - |
 
 ## Legacy Channel Module
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -71,6 +71,37 @@ result = lark.register_app(
 print(result["client_id"])
 ```
 
+### 自定义权限/事件/回调与更新已有应用
+
+创建应用时，可通过 `addons` 在平台基础模板上增量申请权限、事件订阅和回调。这些配置会预填到用户扫码后的确认页中，用户确认后生效：
+
+```python
+result = lark.register_app(
+    on_qr_code=on_qr_code,
+    addons={
+        "scopes": {
+            "tenant": ["im:message:send_as_bot"],
+            "user": ["calendar:calendar:read"],
+        },
+        "events": {"items": {"tenant": ["im.message.receive_v1"]}},
+        "callbacks": {"items": ["card.action.trigger"]},
+    },
+    create_only=True,
+)
+
+lark.register_app(
+    on_qr_code=on_qr_code,
+    app_id="cli_xxx",
+    addons={"scopes": {"tenant": ["drive:drive.metadata:readonly"]}},
+)
+```
+
+注意：
+
+- `addons` 仅支持在基础模板上增量叠加，不支持删减基础权限。
+- 仅支持 5 类公开配置：应用/用户身份权限、应用/用户身份事件、回调。敏感配置（事件请求地址、`security.*`、加密 key 等）不能通过 `addons` 传入。
+- SDK 只校验数据形状，不校验权限点/事件/回调名称是否存在；平台目录中不存在的名称会被确认页忽略。
+
 如需不使用 mock、真实跑一遍手动 E2E：
 
 ```bash
@@ -91,6 +122,14 @@ python3 samples/registration/app_preset_live_e2e.py --open
 | `app_preset.avatar` | 应用头像 URL，支持 1-6 个；传多个时默认选中第一个。图片格式由 Web 页面处理：png / jpg / jpeg / webp / gif | string 或 list[string] | 否 | - |
 | `app_preset.name` | 应用名称，支持 `{user}` 占位符，由 Web 页面替换为扫码用户名称 | string | 否 | - |
 | `app_preset.desc` | 应用描述，支持 `{user}` 占位符 | string | 否 | - |
+| `addons` | 增量权限/事件/回调配置，预填到扫码后的确认页，用户确认后生效 | dict | 否 | - |
+| `addons.scopes.tenant` | 应用身份权限列表，如 `im:message:send_as_bot` | list[string] | 否 | - |
+| `addons.scopes.user` | 用户身份权限列表，如 `calendar:calendar:read` | list[string] | 否 | - |
+| `addons.events.items.tenant` | 应用身份事件列表，如 `im.message.receive_v1` | list[string] | 否 | - |
+| `addons.events.items.user` | 用户身份事件列表，如 `calendar.calendar.event.changed_v4` | list[string] | 否 | - |
+| `addons.callbacks.items` | 回调列表，如 `card.action.trigger` | list[string] | 否 | - |
+| `create_only` | 为 `True` 时落地页仅允许创建新应用，隐藏「选择已有应用」入口。与 `app_id` 同时传入时优先级更高 | bool | 否 | - |
+| `app_id` | 已有应用的 App ID（`cli_` 开头）。传入后流程变为更新该应用配置；二维码 URL 上使用平台参数 `clientID` | string | 否 | - |
 
 ## 旧版 Channel 模块
 

--- a/lark_oapi/core/const.py
+++ b/lark_oapi/core/const.py
@@ -1,6 +1,6 @@
 # Info
 PROJECT = "oapi-sdk-python"
-VERSION = "1.6.8"
+VERSION = "1.6.9"
 
 # Domain
 FEISHU_DOMAIN = "https://open.feishu.cn"

--- a/lark_oapi/scene/registration/__init__.py
+++ b/lark_oapi/scene/registration/__init__.py
@@ -1,4 +1,7 @@
 import asyncio
+import base64
+import gzip
+import json
 import threading
 import time
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
@@ -13,14 +16,115 @@ _SDK_NAME = "python-sdk"
 _AVATAR_MAX_COUNT = 6
 
 
+def _assert_plain_object(value, path):
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must be an object")
+
+
+def _assert_allowed_keys(obj, allowed_keys, path):
+    for key in obj.keys():
+        if key not in allowed_keys:
+            raise ValueError(f"{path}.{key} is not allowed; allowed keys: {', '.join(allowed_keys)}")
+
+
+def _validate_string_list(value, path):
+    if not isinstance(value, list):
+        raise ValueError(f"{path} must be a list of strings")
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or item == "":
+            raise ValueError(f"{path}[{index}] must be a non-empty string")
+
+    return value
+
+
+def _normalize_addons(addons):
+    _assert_plain_object(addons, "addons")
+    _assert_allowed_keys(addons, ["scopes", "events", "callbacks"], "addons")
+
+    item_count = 0
+    normalized = {}
+
+    if "scopes" in addons:
+        scopes = addons["scopes"]
+        _assert_plain_object(scopes, "addons.scopes")
+        _assert_allowed_keys(scopes, ["tenant", "user"], "addons.scopes")
+
+        normalized_scopes = {}
+        for key in ("tenant", "user"):
+            if key in scopes:
+                items = _validate_string_list(scopes[key], f"addons.scopes.{key}")
+                item_count += len(items)
+                normalized_scopes[key] = items
+        normalized["scopes"] = normalized_scopes
+
+    if "events" in addons:
+        events = addons["events"]
+        _assert_plain_object(events, "addons.events")
+        _assert_allowed_keys(events, ["items"], "addons.events")
+
+        if "items" in events:
+            event_items = events["items"]
+            _assert_plain_object(event_items, "addons.events.items")
+            _assert_allowed_keys(event_items, ["tenant", "user"], "addons.events.items")
+
+            normalized_event_items = {}
+            for key in ("tenant", "user"):
+                if key in event_items:
+                    items = _validate_string_list(event_items[key], f"addons.events.items.{key}")
+                    item_count += len(items)
+                    normalized_event_items[key] = items
+            normalized["events"] = {"items": normalized_event_items}
+
+    if "callbacks" in addons:
+        callbacks = addons["callbacks"]
+        _assert_plain_object(callbacks, "addons.callbacks")
+        _assert_allowed_keys(callbacks, ["items"], "addons.callbacks")
+
+        normalized_callbacks = {}
+        if "items" in callbacks:
+            items = _validate_string_list(callbacks["items"], "addons.callbacks.items")
+            item_count += len(items)
+            normalized_callbacks["items"] = items
+        normalized["callbacks"] = normalized_callbacks
+
+    if item_count == 0:
+        raise ValueError("addons must contain at least one scope, event or callback")
+
+    return normalized
+
+
+def _encode_addons(addons):
+    payload = json.dumps(_normalize_addons(addons), ensure_ascii=False, separators=(",", ":"))
+    compressed = gzip.compress(payload.encode("utf-8"), mtime=0)
+    return base64.urlsafe_b64encode(compressed).decode("ascii").rstrip("=")
+
+
 class _RegistrationFlow:
-    def __init__(self, on_qr_code, on_status_change, source, domain, lark_domain, app_preset=None):
+    def __init__(
+            self,
+            on_qr_code,
+            on_status_change,
+            source,
+            domain,
+            lark_domain,
+            app_preset=None,
+            addons=None,
+            create_only=None,
+            app_id=None,
+    ):
+        if app_id is not None and (not isinstance(app_id, str) or app_id == ""):
+            raise ValueError("app_id must be a non-empty string")
+
         self._on_qr_code = on_qr_code
         self._on_status_change = on_status_change
         self._source = source
         self._base_url = domain
         self._lark_url = lark_domain
         self._app_preset = app_preset
+        self._addons = addons
+        self._create_only = create_only
+        self._app_id = app_id
 
     def _apply_app_preset(self, params):
         if not self._app_preset:
@@ -49,6 +153,16 @@ class _RegistrationFlow:
         if desc is not None:
             params["desc"] = desc
 
+    def _apply_registration_options(self, params):
+        if self._addons is not None:
+            params["addons"] = _encode_addons(self._addons)
+
+        if self._create_only is True:
+            params["createOnly"] = "true"
+
+        if self._app_id is not None:
+            params["clientID"] = self._app_id
+
     def _build_qr_url(self, uri):
         parsed = urlparse(uri)
         params = parse_qs(parsed.query)
@@ -58,6 +172,7 @@ class _RegistrationFlow:
         # app_preset values only pre-fill the Web app-creation page. Callers
         # pass raw values; urlencode below handles URL encoding automatically.
         self._apply_app_preset(params)
+        self._apply_registration_options(params)
         return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
 
     def _notify_status(self, status, interval=None):
@@ -106,8 +221,30 @@ class _RegistrationFlow:
 
 
 class _SyncFlow(_RegistrationFlow):
-    def __init__(self, on_qr_code, on_status_change, source, cancel_event, domain, lark_domain, app_preset=None):
-        super().__init__(on_qr_code, on_status_change, source, domain, lark_domain, app_preset)
+    def __init__(
+            self,
+            on_qr_code,
+            on_status_change,
+            source,
+            cancel_event,
+            domain,
+            lark_domain,
+            app_preset=None,
+            addons=None,
+            create_only=None,
+            app_id=None,
+    ):
+        super().__init__(
+            on_qr_code,
+            on_status_change,
+            source,
+            domain,
+            lark_domain,
+            app_preset=app_preset,
+            addons=addons,
+            create_only=create_only,
+            app_id=app_id,
+        )
         self._cancel_event = cancel_event
 
     def _post(self, data):
@@ -244,8 +381,22 @@ def register_app(
         domain="https://accounts.feishu.cn",
         lark_domain="https://accounts.larksuite.com",
         app_preset=None,
+        addons=None,
+        create_only=None,
+        app_id=None,
 ):
-    flow = _SyncFlow(on_qr_code, on_status_change, source, cancel_event, domain, lark_domain, app_preset)
+    flow = _SyncFlow(
+        on_qr_code,
+        on_status_change,
+        source,
+        cancel_event,
+        domain,
+        lark_domain,
+        app_preset=app_preset,
+        addons=addons,
+        create_only=create_only,
+        app_id=app_id,
+    )
     return flow.run()
 
 
@@ -256,6 +407,19 @@ async def aregister_app(
         domain="https://accounts.feishu.cn",
         lark_domain="https://accounts.larksuite.com",
         app_preset=None,
+        addons=None,
+        create_only=None,
+        app_id=None,
 ):
-    flow = _AsyncFlow(on_qr_code, on_status_change, source, domain, lark_domain, app_preset)
+    flow = _AsyncFlow(
+        on_qr_code,
+        on_status_change,
+        source,
+        domain,
+        lark_domain,
+        app_preset=app_preset,
+        addons=addons,
+        create_only=create_only,
+        app_id=app_id,
+    )
     return await flow.run()

--- a/lark_oapi/scene/registration/test_app_preset.py
+++ b/lark_oapi/scene/registration/test_app_preset.py
@@ -1,3 +1,6 @@
+import base64
+import gzip
+import json
 import unittest
 from unittest.mock import patch
 from urllib.parse import parse_qs, quote, urlparse
@@ -9,8 +12,72 @@ def _parse_query(url):
     return parse_qs(urlparse(url).query)
 
 
+def _decode_addons(encoded):
+    padding = "=" * (-len(encoded) % 4)
+    raw = base64.urlsafe_b64decode((encoded + padding).encode("ascii"))
+    return json.loads(gzip.decompress(raw).decode("utf-8"))
+
+
+class AppAddonsEncodingTest(unittest.TestCase):
+    def test_round_trips_full_addons_object(self):
+        addons = {
+            "scopes": {
+                "tenant": ["im:message:send_as_bot", "drive:drive.metadata:readonly"],
+                "user": ["calendar:calendar:read"],
+            },
+            "events": {
+                "items": {
+                    "tenant": ["im.message.receive_v1"],
+                    "user": ["calendar.calendar.event.changed_v4"],
+                }
+            },
+            "callbacks": {"items": ["card.action.trigger"]},
+        }
+
+        encoded = registration._encode_addons(addons)
+
+        self.assertRegex(encoded, r"^[A-Za-z0-9_-]+$")
+        self.assertEqual(_decode_addons(encoded), addons)
+
+    def test_rejects_unknown_top_level_keys(self):
+        with self.assertRaisesRegex(ValueError, r"addons\.security is not allowed"):
+            registration._encode_addons({
+                "scopes": {"tenant": ["im:message:send_as_bot"]},
+                "security": {"allowed_ips": ["1.2.3.4"]},
+            })
+
+    def test_rejects_unknown_nested_keys(self):
+        with self.assertRaisesRegex(ValueError, r"addons\.scopes\.bot is not allowed"):
+            registration._encode_addons({"scopes": {"bot": ["x"]}})
+
+        with self.assertRaisesRegex(ValueError, r"addons\.events\.items\.app is not allowed"):
+            registration._encode_addons({"events": {"items": {"app": ["x"]}}})
+
+    def test_rejects_invalid_leaf_values(self):
+        with self.assertRaisesRegex(ValueError, r"addons\.scopes\.tenant must be a list of strings"):
+            registration._encode_addons({"scopes": {"tenant": "im:message:send_as_bot"}})
+
+        with self.assertRaisesRegex(ValueError, r"addons\.callbacks\.items\[1\] must be a non-empty string"):
+            registration._encode_addons({"callbacks": {"items": ["card.action.trigger", ""]}})
+
+    def test_rejects_empty_addons(self):
+        match = r"at least one scope, event or callback"
+        with self.assertRaisesRegex(ValueError, match):
+            registration._encode_addons({})
+        with self.assertRaisesRegex(ValueError, match):
+            registration._encode_addons({"scopes": {"tenant": [], "user": []}})
+
+
 class AppPresetQRCodeURLTest(unittest.TestCase):
-    def _build_url(self, app_preset=None, source=None, raw_url="https://accounts.feishu.cn/page/launcher?ticket=abc"):
+    def _build_url(
+            self,
+            app_preset=None,
+            source=None,
+            raw_url="https://accounts.feishu.cn/page/launcher?ticket=abc",
+            addons=None,
+            create_only=None,
+            app_id=None,
+    ):
         flow = registration._RegistrationFlow(
             on_qr_code=lambda info: None,
             on_status_change=None,
@@ -18,6 +85,9 @@ class AppPresetQRCodeURLTest(unittest.TestCase):
             domain="https://accounts.feishu.cn",
             lark_domain="https://accounts.larksuite.com",
             app_preset=app_preset,
+            addons=addons,
+            create_only=create_only,
+            app_id=app_id,
         )
         return flow._build_qr_url(raw_url)
 
@@ -28,6 +98,9 @@ class AppPresetQRCodeURLTest(unittest.TestCase):
         self.assertNotIn("avatar", query)
         self.assertNotIn("name", query)
         self.assertNotIn("desc", query)
+        self.assertNotIn("addons", query)
+        self.assertNotIn("createOnly", query)
+        self.assertNotIn("clientID", query)
         self.assertEqual(query["from"], ["sdk"])
         self.assertEqual(query["tp"], ["sdk"])
         self.assertEqual(query["source"], ["python-sdk"])
@@ -116,6 +189,46 @@ class AppPresetQRCodeURLTest(unittest.TestCase):
         self.assertEqual(query["name"], ["MyApp"])
         self.assertEqual(query["desc"], ["demo"])
 
+    def test_encodes_addons_param(self):
+        addons = {
+            "scopes": {"tenant": ["im:message:send_as_bot"], "user": ["calendar:calendar:read"]},
+            "events": {"items": {"tenant": ["im.message.receive_v1"]}},
+            "callbacks": {"items": ["card.action.trigger"]},
+        }
+
+        url = self._build_url(addons=addons)
+        query = _parse_query(url)
+
+        self.assertEqual(_decode_addons(query["addons"][0]), addons)
+
+    def test_keeps_addons_with_app_preset_and_create_only(self):
+        url = self._build_url(
+            app_preset={"name": "MyApp"},
+            addons={"scopes": {"tenant": ["im:message:send_as_bot"]}},
+            create_only=True,
+        )
+        query = _parse_query(url)
+
+        self.assertEqual(_decode_addons(query["addons"][0]), {"scopes": {"tenant": ["im:message:send_as_bot"]}})
+        self.assertEqual(query["name"], ["MyApp"])
+        self.assertEqual(query["createOnly"], ["true"])
+
+    def test_sets_client_id_from_app_id(self):
+        url = self._build_url(app_id="cli_a1b2c3")
+        query = _parse_query(url)
+
+        self.assertEqual(query["clientID"], ["cli_a1b2c3"])
+
+    def test_omits_create_only_when_false(self):
+        url = self._build_url(create_only=False)
+        query = _parse_query(url)
+
+        self.assertNotIn("createOnly", query)
+
+    def test_rejects_empty_app_id(self):
+        with self.assertRaisesRegex(ValueError, r"app_id must be a non-empty string"):
+            self._build_url(app_id="")
+
 
 class AppPresetRegisterAppE2ETest(unittest.TestCase):
     def test_sync_register_app_passes_app_preset_to_qr_url(self):
@@ -146,12 +259,18 @@ class AppPresetRegisterAppE2ETest(unittest.TestCase):
                     "name": "{user}的应用",
                     "desc": "由业务平台自动生成",
                 },
+                addons={"scopes": {"tenant": ["im:message:send_as_bot"]}},
+                create_only=True,
+                app_id="cli_a1b2c3",
             )
 
         query = _parse_query(captured["url"])
         self.assertEqual(query["avatar"], ["https://example.com/a.png", "https://example.com/b.webp"])
         self.assertEqual(query["name"], ["{user}的应用"])
         self.assertEqual(query["desc"], ["由业务平台自动生成"])
+        self.assertEqual(_decode_addons(query["addons"][0]), {"scopes": {"tenant": ["im:message:send_as_bot"]}})
+        self.assertEqual(query["createOnly"], ["true"])
+        self.assertEqual(query["clientID"], ["cli_a1b2c3"])
         self.assertEqual(result["client_id"], "cli_a")
         self.assertEqual(result["client_secret"], "sec_a")
 
@@ -185,11 +304,17 @@ class AppPresetAsyncRegisterAppE2ETest(unittest.IsolatedAsyncioTestCase):
                     "name": "{user}的应用",
                     "desc": "由业务平台自动生成",
                 },
+                addons={"callbacks": {"items": ["card.action.trigger"]}},
+                create_only=True,
+                app_id="cli_a1b2c3",
             )
 
         query = _parse_query(captured["url"])
         self.assertEqual(query["avatar"], ["https://example.com/a.png"])
         self.assertEqual(query["name"], ["{user}的应用"])
         self.assertEqual(query["desc"], ["由业务平台自动生成"])
+        self.assertEqual(_decode_addons(query["addons"][0]), {"callbacks": {"items": ["card.action.trigger"]}})
+        self.assertEqual(query["createOnly"], ["true"])
+        self.assertEqual(query["clientID"], ["cli_a1b2c3"])
         self.assertEqual(result["client_id"], "cli_a")
         self.assertEqual(result["client_secret"], "sec_a")


### PR DESCRIPTION
## Summary

- Add `addons` support to `register_app` / `aregister_app`, including whitelist validation and JSON -> gzip -> base64url encoding for the QR URL.
- Add `create_only` and `app_id` parameters, mapped to the platform QR URL params `createOnly=true` and `clientID`.
- Document the new registration parameters in English and Chinese READMEs.
- Bump the SDK version to `1.6.9`.

## Validation

- `python3 -m pytest -q` -> 658 passed, 2 warnings

Warnings are existing environment/channel-test warnings: urllib3 reports LibreSSL instead of OpenSSL 1.1.1+, and one channel regression test emits an unawaited coroutine warning.