### PR TITLE
feat(registration): support addons.preset flag to switch app base template

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ lark.register_app(
 Notes:
 
 - `addons` is additive only: items are merged on top of the base template; base permissions can never be removed.
+- `addons.preset` picks the base template: omitted or `True` keeps the default base template, while `False` switches to the minimal base template so the final config only contains what `addons` declares. With `"preset": False`, an `addons` without any incremental item is also valid.
 - Only the 5 public config types are supported: tenant/user scopes, tenant/user events, and callbacks. Sensitive config such as event request URLs, `security.*`, or encrypt keys cannot travel through `addons`.
 - The SDK validates the shape, not the item names; names unknown to the platform catalog are ignored by the confirm page.
 
@@ -159,6 +160,7 @@ python3 samples/registration/app_preset_live_e2e.py --open
 | `app_preset.name` | App name. Supports the `{user}` placeholder, replaced by the Web page with the scanning user's name | string | No | - |
 | `app_preset.desc` | App description. Supports the `{user}` placeholder | string | No | - |
 | `addons` | Incremental scopes/events/callbacks pre-filled into the confirm page, effective after user confirmation | dict | No | - |
+| `addons.preset` | Base template switch. Omitted or `True` keeps the default base template; `False` switches to the minimal base template so the app only carries the configs explicitly declared in `addons` | bool | No | `True` |
 | `addons.scopes.tenant` | App-identity scopes, e.g. `im:message:send_as_bot` | list[string] | No | - |
 | `addons.scopes.user` | User-identity scopes, e.g. `calendar:calendar:read` | list[string] | No | - |
 | `addons.events.items.tenant` | App-identity events, e.g. `im.message.receive_v1` | list[string] | No | - |

--- a/README.zh.md
+++ b/README.zh.md
@@ -128,6 +128,7 @@ lark.register_app(
 注意：
 
 - `addons` 仅支持在基础模板上增量叠加，不支持删减基础权限。
+- `addons.preset` 控制底座模板：缺省或 `True` 使用默认底座模板；`False` 切换为最小基础模板，最终配置只包含 `addons` 显式声明的内容。传 `"preset": False` 时，`addons` 可以不带任何增量条目。
 - 仅支持 5 类公开配置：应用/用户身份权限、应用/用户身份事件、回调。敏感配置（事件请求地址、`security.*`、加密 key 等）不能通过 `addons` 传入。
 - SDK 只校验数据形状，不校验权限点/事件/回调名称是否存在；平台目录中不存在的名称会被确认页忽略。
 
@@ -152,6 +153,7 @@ python3 samples/registration/app_preset_live_e2e.py --open
 | `app_preset.name` | 应用名称，支持 `{user}` 占位符，由 Web 页面替换为扫码用户名称 | string | 否 | - |
 | `app_preset.desc` | 应用描述，支持 `{user}` 占位符 | string | 否 | - |
 | `addons` | 增量权限/事件/回调配置，预填到扫码后的确认页，用户确认后生效 | dict | 否 | - |
+| `addons.preset` | 底座模板开关。缺省或 `True` 使用默认底座模板；`False` 切换为最小基础模板，应用配置完全由 `addons` 显式声明 | bool | 否 | `True` |
 | `addons.scopes.tenant` | 应用身份权限列表，如 `im:message:send_as_bot` | list[string] | 否 | - |
 | `addons.scopes.user` | 用户身份权限列表，如 `calendar:calendar:read` | list[string] | 否 | - |
 | `addons.events.items.tenant` | 应用身份事件列表，如 `im.message.receive_v1` | list[string] | 否 | - |

--- a/lark_oapi/core/const.py
+++ b/lark_oapi/core/const.py
@@ -1,6 +1,6 @@
 # Info
 PROJECT = "oapi-sdk-python"
-VERSION = "1.7.0"
+VERSION = "1.8.0"
 
 # Domain
 FEISHU_DOMAIN = "https://open.feishu.cn"

--- a/lark_oapi/core/const.py
+++ b/lark_oapi/core/const.py
@@ -1,6 +1,6 @@
 # Info
 PROJECT = "oapi-sdk-python"
-VERSION = "1.8.0"
+VERSION = "1.7.1"
 
 # Domain
 FEISHU_DOMAIN = "https://open.feishu.cn"

--- a/lark_oapi/scene/registration/__init__.py
+++ b/lark_oapi/scene/registration/__init__.py
@@ -40,10 +40,16 @@ def _validate_string_list(value, path):
 
 def _normalize_addons(addons):
     _assert_plain_object(addons, "addons")
-    _assert_allowed_keys(addons, ["scopes", "events", "callbacks"], "addons")
+    _assert_allowed_keys(addons, ["preset", "scopes", "events", "callbacks"], "addons")
 
     item_count = 0
     normalized = {}
+
+    if "preset" in addons:
+        preset = addons["preset"]
+        if not isinstance(preset, bool):
+            raise ValueError("addons.preset must be a boolean")
+        normalized["preset"] = preset
 
     if "scopes" in addons:
         scopes = addons["scopes"]
@@ -88,8 +94,13 @@ def _normalize_addons(addons):
             normalized_callbacks["items"] = items
         normalized["callbacks"] = normalized_callbacks
 
-    if item_count == 0:
-        raise ValueError("addons must contain at least one scope, event or callback")
+    # preset=false declares the minimal base template, so an addons payload
+    # without any incremental item is still meaningful in that case.
+    if item_count == 0 and normalized.get("preset") is not False:
+        message = "addons must contain at least one scope, event or callback"
+        if "preset" in normalized:
+            message += ", or set preset to false"
+        raise ValueError(message)
 
     return normalized
 

--- a/lark_oapi/scene/registration/test_app_preset.py
+++ b/lark_oapi/scene/registration/test_app_preset.py
@@ -230,6 +230,152 @@ class AppPresetQRCodeURLTest(unittest.TestCase):
             self._build_url(app_id="")
 
 
+class AddonsPresetEncodingTest(unittest.TestCase):
+    def test_accepts_preset_false_alone_as_minimal_base_payload(self):
+        encoded = registration._encode_addons({"preset": False})
+
+        self.assertEqual(_decode_addons(encoded), {"preset": False})
+
+    def test_keeps_preset_false_alongside_scope_entries(self):
+        addons = {"preset": False, "scopes": {"tenant": ["im:message:send_as_bot"]}}
+
+        encoded = registration._encode_addons(addons)
+
+        self.assertEqual(_decode_addons(encoded), addons)
+
+    def test_preserves_explicit_preset_true_in_payload(self):
+        addons = {"preset": True, "scopes": {"tenant": ["x"]}}
+
+        encoded = registration._encode_addons(addons)
+
+        self.assertEqual(_decode_addons(encoded), addons)
+
+    def test_rejects_non_boolean_preset_values(self):
+        # 1 和 0 在 Python 里是 bool 的父类 int 的值，容易被 isinstance(x, int)
+        # 式的校验误放行，必须与字符串、None 一样显式拒绝。
+        for value in ("false", 1, 0, None):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, r"addons\.preset must be a boolean"):
+                    registration._encode_addons({"preset": value})
+
+    def test_preset_false_does_not_relax_top_level_key_whitelist(self):
+        with self.assertRaisesRegex(ValueError, r"addons\.security is not allowed"):
+            registration._encode_addons({
+                "preset": False,
+                "security": {"allowed_ips": ["1.2.3.4"]},
+            })
+
+    def test_rejects_preset_true_without_any_entries(self):
+        with self.assertRaisesRegex(ValueError, r"at least one scope, event or callback"):
+            registration._encode_addons({"preset": True})
+
+    def test_keeps_rejecting_empty_addons_without_preset(self):
+        # 回归护栏：引入 preset 后，缺省的空 payload 仍必须沿用既有报错，
+        # 逐字不变——preset 相关的提示语只允许出现在显式传了 preset 时。
+        match = r"^addons must contain at least one scope, event or callback$"
+        with self.assertRaisesRegex(ValueError, match):
+            registration._encode_addons({})
+        with self.assertRaisesRegex(ValueError, match):
+            registration._encode_addons({"scopes": {"tenant": []}})
+
+    def test_accepts_preset_false_with_empty_scope_lists(self):
+        addons = {"preset": False, "scopes": {"tenant": []}}
+
+        encoded = registration._encode_addons(addons)
+
+        self.assertEqual(_decode_addons(encoded), addons)
+
+    def test_omits_preset_key_when_not_provided(self):
+        encoded = registration._encode_addons({"scopes": {"tenant": ["x"]}})
+
+        self.assertNotIn("preset", _decode_addons(encoded))
+
+
+class AddonsPresetQRCodeURLTest(unittest.TestCase):
+    def test_addons_query_param_carries_preset_false(self):
+        addons = {"preset": False, "scopes": {"tenant": ["im:message:send_as_bot"]}}
+        flow = registration._RegistrationFlow(
+            on_qr_code=lambda info: None,
+            on_status_change=None,
+            source=None,
+            domain="https://accounts.feishu.cn",
+            lark_domain="https://accounts.larksuite.com",
+            app_preset=None,
+            addons=addons,
+            create_only=None,
+            app_id=None,
+        )
+
+        url = flow._build_qr_url("https://accounts.feishu.cn/page/launcher?ticket=abc")
+        query = _parse_query(url)
+
+        self.assertEqual(_decode_addons(query["addons"][0]), addons)
+        self.assertEqual(query["from"], ["sdk"])
+        self.assertEqual(query["tp"], ["sdk"])
+        self.assertEqual(query["source"], ["python-sdk"])
+        self.assertEqual(query["ticket"], ["abc"])
+
+
+def _device_flow_responses():
+    return [
+        {"supported_auth_methods": ["client_secret"]},
+        {
+            "device_code": "dev-1",
+            "verification_uri_complete": "https://accounts.feishu.cn/page/launcher",
+            "interval": 1,
+            "expires_in": 60,
+        },
+        {
+            "client_id": "cli_a",
+            "client_secret": "sec_a",
+            "user_info": {"open_id": "ou_x", "tenant_brand": "feishu"},
+        },
+    ]
+
+
+class AddonsPresetRegisterAppE2ETest(unittest.TestCase):
+    def test_sync_register_app_passes_addons_preset_to_qr_url(self):
+        responses = _device_flow_responses()
+
+        def fake_post(self, data):
+            return responses.pop(0)
+
+        addons = {"preset": False, "scopes": {"tenant": ["im:message:send_as_bot"]}}
+        captured = {}
+        with patch.object(registration._SyncFlow, "_post", fake_post):
+            result = registration.register_app(
+                on_qr_code=lambda info: captured.update(info),
+                addons=addons,
+            )
+
+        query = _parse_query(captured["url"])
+        self.assertEqual(_decode_addons(query["addons"][0]), addons)
+        self.assertEqual(result["client_id"], "cli_a")
+        self.assertEqual(result["client_secret"], "sec_a")
+
+
+class AddonsPresetAsyncRegisterAppE2ETest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_register_app_passes_addons_preset_to_qr_url(self):
+        responses = _device_flow_responses()
+
+        async def fake_post(self, data):
+            return responses.pop(0)
+
+        # 近空应用场景：最小底座 + 无任何增量条目，走完整异步注册链路。
+        addons = {"preset": False}
+        captured = {}
+        with patch.object(registration._AsyncFlow, "_post", fake_post):
+            result = await registration.aregister_app(
+                on_qr_code=lambda info: captured.update(info),
+                addons=addons,
+            )
+
+        query = _parse_query(captured["url"])
+        self.assertEqual(_decode_addons(query["addons"][0]), addons)
+        self.assertEqual(result["client_id"], "cli_a")
+        self.assertEqual(result["client_secret"], "sec_a")
+
+
 class AppPresetRegisterAppE2ETest(unittest.TestCase):
     def test_sync_register_app_passes_app_preset_to_qr_url(self):
         responses = [


### PR DESCRIPTION
## What

Add support for the top-level `preset` boolean field in the `addons` parameter of `register_app` / `aregister_app`.

- `preset` omitted or `True` (default): the app is created on top of the default base template, with `addons` items merged in — same behavior as before.
- `preset: False`: switches to the minimal base template, so the final app config only contains what `addons` explicitly declares. In this mode an `addons` payload without any incremental item is also valid.

## Why

The open platform app-creation page now supports choosing the base template through the encoded `addons` query parameter. SDK callers that need fully self-declared app configs (avoiding drift from the default template) can now opt in with `addons={"preset": False, ...}`.

## Behavior details

- `preset` must be a real boolean; `1` / `0` / strings / `None` are rejected with `ValueError: addons.preset must be a boolean`.
- An explicitly passed value is encoded verbatim into the payload; when omitted, the key is absent and the encoded bytes are unchanged from previous versions (fully backward compatible, error messages for existing invalid inputs are byte-identical).
- The existing key whitelist and string-list validation are unchanged; `preset` does not relax them.

## Docs

`README.md` / `README.zh.md`: added the `addons.preset` row to the `register_app` parameter table plus a usage note.

## Tests

- 12 new unit tests in `lark_oapi/scene/registration/test_app_preset.py`: encoding round-trips (`False` alone, `False`+scopes, explicit `True`), non-boolean rejection (incl. the bool-is-int trap), whitelist regression, empty-payload validity matrix, QR-URL query pass-through, sync/async full-flow with mocked transport, and a guard pinning that the key is omitted when not provided.
- All pre-existing tests pass unmodified.

## Version

`1.7.0` → `1.7.1` (patch).
