### PR TITLE
fix(ws): redact credentials from connection logs

### DIFF
--- a/lark_oapi/ws/client.py
+++ b/lark_oapi/ws/client.py
@@ -80,6 +80,42 @@ def _ws_connect_kwargs():
     return {}
 
 
+def _redact_conn_url_for_log(url: str) -> str:
+    query_start = url.find("?")
+    fragment_start = url.find("#")
+    if query_start == -1 or 0 <= fragment_start < query_start:
+        return url
+
+    query_end = fragment_start
+    if query_end == -1:
+        query_end = len(url)
+
+    redacted = []
+    cursor = query_start + 1
+    while cursor <= query_end:
+        param_end = url.find("&", cursor, query_end)
+        if param_end == -1:
+            param_end = query_end
+
+        equals = url.find("=", cursor, param_end)
+        if equals != -1:
+            key = url[cursor:equals]
+            if key.isascii() and key.lower() in ("access_key", "ticket"):
+                redacted.append(url[cursor:equals + 1])
+                redacted.append("***")
+            else:
+                redacted.append(url[cursor:param_end])
+        else:
+            redacted.append(url[cursor:param_end])
+
+        if param_end == query_end:
+            break
+        redacted.append("&")
+        cursor = param_end + 1
+
+    return url[:query_start + 1] + "".join(redacted) + url[query_end:]
+
+
 def _get_ws_conn_exception_headers(e):
     headers = getattr(e, "headers", None)
     if headers is not None:
@@ -207,7 +243,7 @@ class Client(object):
             self._conn_id = conn_id
             self._service_id = service_id
 
-            logger.info(self._fmt_log("connected to {}", conn_url))
+            logger.info(self._fmt_log("connected to {}", _redact_conn_url_for_log(conn_url)))
             loop.create_task(self._receive_message_loop())
         except InvalidHandshake as e:
             _parse_ws_conn_exception(e)
@@ -413,7 +449,7 @@ class Client(object):
             if self._conn is None:
                 return
             await self._conn.close()
-            logger.info(self._fmt_log("disconnected to {}", self._conn_url))
+            logger.info(self._fmt_log("disconnected to {}", _redact_conn_url_for_log(self._conn_url)))
         finally:
             self._conn = None
             self._conn_url = ""

--- a/lark_oapi/ws/tests/test_client_log_redaction.py
+++ b/lark_oapi/ws/tests/test_client_log_redaction.py
@@ -1,0 +1,60 @@
+import logging
+
+import pytest
+
+from lark_oapi.ws import client as ws_client
+
+
+class _FakeConn:
+    async def close(self):
+        pass
+
+
+def test_redaction_does_not_treat_fragment_text_as_query():
+    url = "wss://example.test/callback#section?access_key=visible"
+
+    assert ws_client._redact_conn_url_for_log(url) == url
+
+
+@pytest.mark.asyncio
+async def test_connection_lifecycle_logs_redact_only_sensitive_query_values(monkeypatch, caplog):
+    conn_url = (
+        "wss://example.test/callback?device_id=device%20one&service_id=42"
+        "&access_key=fake%20access%2Fpart&TICKET=Fake%2fticket&ticket&flag&empty="
+        "&ticket=second-fake&access_key=&access_key_extra=visible#section%20one"
+    )
+    redacted_url = (
+        "wss://example.test/callback?device_id=device%20one&service_id=42"
+        "&access_key=***&TICKET=***&ticket&flag&empty="
+        "&ticket=***&access_key=***&access_key_extra=visible#section%20one"
+    )
+    connected_urls = []
+
+    async def fake_connect(uri):
+        connected_urls.append(uri)
+        return _FakeConn()
+
+    client = ws_client.Client("fake_app_id", "fake_app_secret")
+    monkeypatch.setattr(client, "_get_conn_url", lambda: conn_url)
+    monkeypatch.setattr(ws_client.websockets, "connect", fake_connect)
+    monkeypatch.setattr(
+        ws_client.loop,
+        "create_task",
+        lambda coro: coro.close() if hasattr(coro, "close") else None,
+    )
+
+    with caplog.at_level(logging.INFO, logger="Lark"):
+        await client._connect()
+        await client._disconnect()
+
+    lifecycle_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "connected to " in record.getMessage() or "disconnected to " in record.getMessage()
+    ]
+
+    assert connected_urls == [conn_url]
+    assert lifecycle_messages == [
+        "connected to {} [conn_id=device one]".format(redacted_url),
+        "disconnected to {} [conn_id=device one]".format(redacted_url),
+    ]

--- a/lark_oapi/ws/tests/test_client_log_redaction.py
+++ b/lark_oapi/ws/tests/test_client_log_redaction.py
@@ -45,6 +45,7 @@ async def test_connection_lifecycle_logs_redact_only_sensitive_query_values(monk
 
     with caplog.at_level(logging.INFO, logger="Lark"):
         await client._connect()
+        assert client._conn_url == conn_url
         await client._disconnect()
 
     lifecycle_messages = [


### PR DESCRIPTION
## Summary

- redact `access_key` and `ticket` values in WebSocket connection and disconnection INFO logs
- preserve every other URL byte, including query ordering, percent-encoding, empty/value-less parameters, repeats, and fragments
- keep the original URL for `websockets.connect()` and `Client._conn_url`

Closes #141.

## Root cause

`Client._connect()` and `_disconnect()` formatted the complete server-provided WebSocket URL directly into lifecycle logs. That URL carries sensitive authentication query values.

The fix uses a small log-only scanner. It replaces only the value bytes of ASCII case-insensitive `access_key` and `ticket` keys, without parsing or normalizing the URL.

## Tests

```text
pytest -q lark_oapi/ws/tests/test_client_log_redaction.py
2 passed, 2 warnings

pytest -q lark_oapi/ws/tests/
15 passed, 2 warnings

git diff --check origin/v2_main..HEAD
clean
```

The regression test proves that:

- connect and disconnect each emit a redacted lifecycle message;
- the original sensitive values are absent from both messages;
- non-sensitive URL bytes remain unchanged;
- `websockets.connect()` receives the exact original URL; and
- `Client._conn_url` retains the exact original URL until disconnect.

## Environment and limits

- WSL2 Ubuntu on Windows 11
- Python 3.12 test virtual environment
- no real Lark credentials or live WebSocket endpoint were used
- the WS suite still reports pre-existing event-loop/cache cleanup and deprecation warnings; all tests exit successfully
