### PR TITLE
fix(channel): populate InboundMessage.mentioned_bot from mentions (fixes #134)

### DIFF
--- a/lark_oapi/channel/channel.py
+++ b/lark_oapi/channel/channel.py
@@ -1156,6 +1156,7 @@ class FeishuChannel:
                 event_id=event_id,
                 message_event=message,
                 sender=sender,
+                bot_open_id=self._bot_open_id,
             )
             if inbound is None:
                 return

--- a/lark_oapi/channel/normalize/pipeline.py
+++ b/lark_oapi/channel/normalize/pipeline.py
@@ -128,6 +128,7 @@ class InboundPipeline:
             event_id: Optional[str],
             message_event: Any,
             sender: Any,
+            bot_open_id: Optional[str] = None,
     ) -> Optional[InboundMessage]:
         """Return InboundMessage or None if the event was deduped / filtered."""
         msg = _message_to_dict(message_event)
@@ -159,8 +160,10 @@ class InboundPipeline:
         content = parse_message_content(message_type, msg.get("content"))
 
         # Process mentions for text / post (node-aligned: extract → resolve).
+        # ``bot_open_id`` lets extract_mentions flag self-mentions so
+        # ``InboundMessage.mentioned_bot`` is correct (fixes #134).
         raw_mentions = msg.get("mentions") or []
-        ext = extract_mentions(raw_mentions)
+        ext = extract_mentions(raw_mentions, bot_open_id=bot_open_id)
         mentions: List[Mention] = list(ext.mention_list)
         mentioned_all = ext.mentioned_all
         if isinstance(content, TextContent):
@@ -257,6 +260,7 @@ class InboundPipeline:
             sender=sender_identity,
             mentions=mentions,
             mentioned_all=mentioned_all,
+            mentioned_bot=ext.mentioned_bot,
             reply=reply,
             content=content,
             raw=msg if isinstance(msg, dict) else {},

--- a/lark_oapi/channel/tests/test_pipeline.py
+++ b/lark_oapi/channel/tests/test_pipeline.py
@@ -186,3 +186,54 @@ async def test_interactive_is_refetched_and_version_detected():
     inbound = await p.process(event_id="e", message_event=msg, sender=_sender())
     assert isinstance(inbound.content, InteractiveContent)
     assert inbound.content.card_version == "v2"
+
+
+# ---------------------------------------------------------------------------
+# mentioned_bot (#134): the field must be set when the bot is in mentions[]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mentioned_bot_true_when_bot_in_mentions():
+    msg = _msg(
+        mentions=[
+            {"key": "@_user_1", "id": {"open_id": "ou_user"}, "name": "Alice"},
+            {"key": "@_user_2", "id": {"open_id": "ou_bot"}, "name": "my-bot"},
+        ]
+    )
+    p = InboundPipeline(PipelineConfig(), PipelineDeps())
+    inbound = await p.process(
+        event_id="e", message_event=msg, sender=_sender(), bot_open_id="ou_bot"
+    )
+    assert inbound is not None
+    assert inbound.mentioned_bot is True
+    # the bot self-mention is excluded from the public mention list
+    assert [m.open_id for m in inbound.mentions] == ["ou_user"]
+
+
+@pytest.mark.asyncio
+async def test_mentioned_bot_false_without_bot_open_id():
+    msg = _msg(
+        mentions=[{"key": "@_user_1", "id": {"open_id": "ou_user"}, "name": "Alice"}]
+    )
+    p = InboundPipeline(PipelineConfig(), PipelineDeps())
+    inbound = await p.process(event_id="e", message_event=msg, sender=_sender())
+    assert inbound is not None
+    assert inbound.mentioned_bot is False
+
+
+@pytest.mark.asyncio
+async def test_mentioned_bot_false_when_bot_not_mentioned():
+    msg = _msg(
+        mentions=[
+            {"key": "@_user_1", "id": {"open_id": "ou_user"}, "name": "Alice"},
+            {"key": "@_user_2", "id": {"open_id": "ou_other"}, "name": "Bob"},
+        ]
+    )
+    p = InboundPipeline(PipelineConfig(), PipelineDeps())
+    inbound = await p.process(
+        event_id="e", message_event=msg, sender=_sender(), bot_open_id="ou_bot"
+    )
+    assert inbound is not None
+    assert inbound.mentioned_bot is False
+    assert len(inbound.mentions) == 2


### PR DESCRIPTION
Fixes #134

## Problem

`InboundMessage.mentioned_bot` is unconditionally `False` for every IM message, even when the bot is explicitly mentioned and the bot identity is resolved. Two compounding omissions in `lark_oapi/channel/normalize/pipeline.py`:

1. `extract_mentions(raw_mentions)` never receives `bot_open_id`, so `mentions.py` can never flag the bot self-mention.
2. Even when computed, `ext.mentioned_bot` is never forwarded to the `InboundMessage(...)` constructor — it falls back to its `False` default.

The internal `PolicyGate` works around this by re-computing the check inline (`policy_gate.py`), which confirms the field is known to be unreliable — but every `on("message")` consumer reading `msg.mentioned_bot` always gets `False`, causing "bot is @-mentioned but does not respond" bugs.

The comment path already does this correctly: `_handle_comment_event` passes `bot_open_id=self._bot_open_id` into `normalize_comment`.

## Changes

- **`pipeline.py`**: `process()` accepts an optional `bot_open_id`; it is forwarded to `extract_mentions`, and `ext.mentioned_bot` is now passed to `InboundMessage(...)`.
- **`channel.py`**: `_handle_message_event` passes `bot_open_id=self._bot_open_id` (same source the comment path uses).
- **`tests/test_pipeline.py`**: 3 new tests — bot in `mentions[]` → `mentioned_bot=True` (and the bot self-mention excluded from the public `mentions` list); no `bot_open_id` → `False`; bot not mentioned → `False`.

## Verification

- `python -m pytest lark_oapi/channel/tests` — 660 passed; the single failure (`test_upload_error_propagation.py::test_gather_buffer_missing_local_file_raises_upload_failed`) is a pre-existing Windows-only path-escaping assertion that does not touch this code path (CI runs on Linux).