### PR TITLE
fix(ws): drop deprecated datetime.utcfromtimestamp/utcnow in vendored well_known_types

### DIFF
--- a/lark_oapi/ws/pb/google/protobuf/internal/well_known_types.py
+++ b/lark_oapi/ws/pb/google/protobuf/internal/well_known_types.py
@@ -88,7 +88,7 @@ class Any(object):
         return '/' in self.type_url and self.TypeName() == descriptor.full_name
 
 
-_EPOCH_DATETIME_NAIVE = datetime.datetime.utcfromtimestamp(0)
+_EPOCH_DATETIME_NAIVE = datetime.datetime(1970, 1, 1)
 _EPOCH_DATETIME_AWARE = datetime.datetime.fromtimestamp(
     0, tz=datetime.timezone.utc)
 
@@ -192,7 +192,7 @@ class Timestamp(object):
 
     def GetCurrentTime(self):
         """Get the current UTC into Timestamp."""
-        self.FromDatetime(datetime.datetime.utcnow())
+        self.FromDatetime(datetime.datetime.now(tz=datetime.timezone.utc))
 
     def ToNanoseconds(self):
         """Converts Timestamp to nanoseconds since epoch."""

--- a/lark_oapi/ws/tests/test_well_known_types_timestamp.py
+++ b/lark_oapi/ws/tests/test_well_known_types_timestamp.py
@@ -1,0 +1,32 @@
+import datetime
+import time
+import warnings
+
+from lark_oapi.ws.pb.google.protobuf import timestamp_pb2
+
+
+def test_timestamp_get_current_time_no_deprecation_warning():
+    """GetCurrentTime must not emit DeprecationWarning (issue #145)."""
+    ts = timestamp_pb2.Timestamp()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        ts.GetCurrentTime()
+    assert abs(ts.ToSeconds() - time.time()) < 5
+
+
+def test_timestamp_from_to_datetime_roundtrip_naive():
+    ts = timestamp_pb2.Timestamp()
+    ts.FromDatetime(datetime.datetime(2024, 1, 2, 3, 4, 5, 123456))
+    dt = ts.ToDatetime()
+    assert dt == datetime.datetime(2024, 1, 2, 3, 4, 5, 123456)
+
+
+def test_timestamp_from_to_datetime_roundtrip_aware():
+    ts = timestamp_pb2.Timestamp()
+    ts.FromDatetime(
+        datetime.datetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=datetime.timezone.utc)
+    )
+    dt = ts.ToDatetime(tzinfo=datetime.timezone.utc)
+    assert dt == datetime.datetime(
+        2024, 1, 2, 3, 4, 5, 123456, tzinfo=datetime.timezone.utc
+    )


### PR DESCRIPTION
Fixes #145.

## Problem

The vendored `lark_oapi/ws/pb/google/protobuf/internal/well_known_types.py` still calls `datetime.datetime.utcfromtimestamp(0)` and `datetime.datetime.utcnow()`, both deprecated since Python 3.12 and scheduled for removal — every import of the ws protobuf runtime on Python 3.13/3.14 emits a `DeprecationWarning`.

## Change

Mirrors the upstream `google.protobuf` fix:

- `_EPOCH_DATETIME_NAIVE = datetime.datetime(1970, 1, 1)` — identical value, no deprecated call.
- `Timestamp.GetCurrentTime()` uses `datetime.datetime.now(tz=datetime.timezone.utc)`.

## Tests

New `lark_oapi/ws/tests/test_well_known_types_timestamp.py`:

- `GetCurrentTime()` under `warnings.simplefilter("error", DeprecationWarning)` and sanity-checked against `time.time()`.
- `FromDatetime`/`ToDatetime` roundtrips for naive and timezone-aware datetimes.

## Verification

- `python -m pytest lark_oapi/ws/tests/test_well_known_types_timestamp.py` — 3/3 pass.
- `python -m pytest` (default suite) — 666 pass; the single failing `test_upload_error_propagation` case is the pre-existing Windows-only path-escape issue (CI runs Linux).
