### PR TITLE
fix: support websockets 16

### DIFF
--- a/lark_oapi/ws/tests/test_websockets_compat.py
+++ b/lark_oapi/ws/tests/test_websockets_compat.py
@@ -83,7 +83,7 @@ def test_get_conn_url_sends_custom_headers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_connect_disables_websockets_15_automatic_proxy(monkeypatch):
+async def test_connect_disables_websockets_15_and_16_automatic_proxy(monkeypatch):
     captured = {}
 
     async def fake_connect(uri, *, proxy=True):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(
         "requests>=2.25",
         "requests_toolbelt>=0.9",
         "pycryptodome>=3.9",
-        "websockets>=11,<16",
+        # websockets 16 requires Python >=3.10; pip selects an older compatible
+        # release when installing the SDK on Python 3.8 or 3.9.
+        "websockets>=11,<17",
         "httpx>=0.24,<1.0",
     ],
     extras_require={


### PR DESCRIPTION
## Summary

- allow installing websockets 16 by relaxing the upper bound to `<17`
- document Python 3.8/3.9 dependency resolution behavior
- clarify that the automatic proxy compatibility test covers websockets 15 and 16

## Testing

- `python -m pytest lark_oapi/ws/tests/test_websockets_compat.py -q` (5 passed)
- `python -m pytest -q` (658 passed)
- tested with websockets 16.1.1