### PR TITLE
fix(channel): track bot identity retry task

### DIFF
--- a/lark_oapi/channel/channel.py
+++ b/lark_oapi/channel/channel.py
@@ -972,9 +972,7 @@ class FeishuChannel:
         if self._bg_loop is None:
             return
         try:
-            asyncio.run_coroutine_threadsafe(
-                self._bot_identity_retry_loop(), self._bg_loop
-            )
+            self.schedule(self._bot_identity_retry_loop())
         except RuntimeError:  # pragma: no cover - loop already stopped
             pass
 

--- a/lark_oapi/channel/tests/test_reliability.py
+++ b/lark_oapi/channel/tests/test_reliability.py
@@ -177,6 +177,24 @@ async def test_bot_identity_retry_loop_respects_shutdown():
     ch.stop()
 
 
+def test_bot_identity_retry_task_is_cancelled_on_stop():
+    """The fire-and-forget retry must participate in channel shutdown."""
+    ch = _channel()
+    ch._ensure_bg_loop()
+    ch._BOT_IDENTITY_RETRY_DELAYS_S = (3600,)
+
+    ch._start_bot_identity_retry_loop()
+
+    with ch._bg_tasks_lock:
+        pending = list(ch._bg_tasks)
+    assert len(pending) == 1
+    assert not pending[0].done()
+
+    ch.stop()
+
+    assert pending[0].cancelled()
+
+
 def test_bot_identity_store_is_atomic_under_concurrent_writes():
     """Two threads writing the identity simultaneously must never leave
     the pair of fields in a half-updated state (fresh ``_bot_identity`` +


### PR DESCRIPTION
## Problem

`_start_bot_identity_retry_loop()` submitted its coroutine directly with `asyncio.run_coroutine_threadsafe()` and discarded the future. The channel's `stop()` method only cancels futures tracked in `_bg_tasks`, so a retry sleeping in the backoff schedule survived loop shutdown and emitted `Task was destroyed but it is pending!`.

## Root cause and solution

Route the retry through the existing `FeishuChannel.schedule()` helper. That helper already owns the lifecycle contract for background work: it tracks futures, logs exceptions, and lets `stop()` cancel them.

A regression test starts a retry with a long delay, verifies that it is tracked and still pending, calls `stop()`, and verifies the captured future is cancelled.

## Verification

- `python -m pytest -q -p no:cacheprovider lark_oapi/channel/tests/test_reliability.py` — 7 passed
- `python -m pytest -q -p no:cacheprovider -k 'not test_gather_buffer_missing_local_file_raises_upload_failed'` — 658 passed, 1 deselected
- The deselected Windows-only baseline failure is tracked separately in #160.

Closes #159