### PR TITLE
test(channel): make upload path assertion portable

### DIFF
--- a/lark_oapi/channel/tests/test_upload_error_propagation.py
+++ b/lark_oapi/channel/tests/test_upload_error_propagation.py
@@ -34,7 +34,7 @@ async def test_gather_buffer_missing_local_file_raises_upload_failed(tmp_path):
         await gather_buffer(source, "fallback.bin")
     err = ei.value
     assert err.code == FeishuChannelErrorCode.UPLOAD_FAILED
-    assert nonexistent in str(err)
+    assert repr(nonexistent) in str(err)
     # Concrete OSError preserved via ``from e`` — callers can inspect.
     assert err.__cause__ is not None
     assert isinstance(err.__cause__, OSError)


### PR DESCRIPTION
## Problem

The missing-file upload regression test compared the raw Windows path with an exception message that intentionally formats the path using `repr()`. Backslashes are escaped in that representation, so the assertion failed on Windows even though the original path remained intact in the structured error context.

## Solution

Assert the representation that the production message actually promises. The existing exact `err.context["path"]` assertion continues to verify that callers receive the unmodified path value.

## Verification

Windows 11 / Python 3.13.13:

- `python -m pytest -q -p no:cacheprovider lark_oapi/channel/tests/test_upload_error_propagation.py` — 8 passed
- `python -m pytest -q -p no:cacheprovider` — 658 passed

One first full-suite run hit a pre-existing timing failure in `test_stop_during_pre_ws_start_prevents_late_ws_creation`; that test passed on two immediate focused reruns, and the subsequent full-suite rerun passed. This one-line assertion change does not touch lifecycle code.

Closes #160