### PR TITLE
docs(channel): fix CardKit sequence example

### DIFF
--- a/doc/channel/cardkit-streaming.md
+++ b/doc/channel/cardkit-streaming.md
@@ -68,17 +68,18 @@ strictly increasing `sequence` number per `card_id`.
 Recommended pattern:
 
 ```python
-seq = 0
+async def stream_updates():
+    seq = 0
 
-async def patch(text):
-    nonlocal seq
+    async def patch(text):
+        nonlocal seq
+        seq += 1
+        await channel.update_card_element_content(card_id, "main", text, sequence=seq)
+
+    # ... stream tokens, calling patch() ...
+
     seq += 1
-    await channel.update_card_element_content(card_id, "main", text, sequence=seq)
-
-# ... stream tokens, calling patch() ...
-
-seq += 1
-await channel.finish_streaming_card(card_id, sequence=seq)
+    await channel.finish_streaming_card(card_id, sequence=seq)
 ```
 
 ## `finish_streaming_card` vs `update_card`


### PR DESCRIPTION
## Problem

The recommended CardKit sequence snippet declared `seq` at module scope and used `nonlocal seq` inside a nested helper. Python rejects that because `nonlocal` requires an enclosing function binding.

## Solution

Put the sequence state and helper inside an async `stream_updates()` function. This keeps the intended closure-based increment pattern while making the snippet syntactically valid and preserving the documented sequence semantics.

## Verification

- Compiled every explicit Python fence in all tracked Markdown with `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` — 71 fences, 0 failures
- `python -m compileall -q -f doc` — passed
- `git diff --check` — passed

Closes #161