### PR TITLE
feat(channel): render post attachment zone in normalize

### DIFF
--- a/lark_oapi/channel/normalize/converters/post.py
+++ b/lark_oapi/channel/normalize/converters/post.py
@@ -3,12 +3,29 @@
 from typing import Any, Dict, List, Tuple
 
 from ...types import PostContent, ResourceDescriptor
+from ._utils import attr
 
 
 def convert(content: PostContent) -> Tuple[str, List[ResourceDescriptor]]:
     md = _post_to_markdown(content.post) if content.post else content.text
     resources = _post_resources(content.post) if content.post else []
     return md, resources
+
+
+def _attachment_files(post: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Top-level attachment zone (``files`` array) of a post message.
+
+    The rich-text attachment zone lives at the top level of the post JSON,
+    outside any locale document: ``files: [{file_key, file_name, is_folder}]``.
+    Standalone file/folder tags are rendered the same way as the file/folder
+    message converters (``<file key="..." name="..."/>`` / ``<folder .../>``).
+    """
+    if not isinstance(post, dict):
+        return []
+    files = post.get("files")
+    if not isinstance(files, list):
+        return []
+    return [f for f in files if isinstance(f, dict) and isinstance(f.get("file_key"), str) and f["file_key"]]
 
 
 def _iter_documents(post: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -68,6 +85,19 @@ def _post_to_markdown(post: Dict[str, Any]) -> str:
         line = "".join(chunks)
         if line:
             lines.append(line)
+    for f in _attachment_files(post):
+        key = f["file_key"]
+        name = f.get("file_name") or ""
+        if f.get("is_folder"):
+            if name:
+                lines.append(f'<folder key="{key}" name="{attr(name)}"/>')
+            else:
+                lines.append(f'<folder key="{key}"/>')
+        else:
+            if name:
+                lines.append(f'<file key="{key}" name="{attr(name)}"/>')
+            else:
+                lines.append(f'<file key="{key}"/>')
     return "\n\n".join(lines).strip()
 
 
@@ -104,4 +134,10 @@ def _post_resources(post: Dict[str, Any]) -> List[ResourceDescriptor]:
                     add("audio", el.get("file_key"))
                 elif tag == "file":
                     add("file", el.get("file_key"), file_name=el.get("file_name"))
+    # Attachment zone: files are downloadable resources; folders are rendered
+    # as tags only (mirrors the standalone folder converter, resources=[]).
+    for f in _attachment_files(post):
+        if f.get("is_folder"):
+            continue
+        add("file", f.get("file_key"), file_name=f.get("file_name"))
     return resources

--- a/lark_oapi/channel/tests/test_flatten.py
+++ b/lark_oapi/channel/tests/test_flatten.py
@@ -133,6 +133,42 @@ def test_post_resources_include_images_media_audio_and_files_deduped():
     ]
 
 
+def test_post_attachment_zone_renders_files_and_folders():
+    # Attachment zone lives at the top level of the post JSON, outside the
+    # locale document: files: [{file_key, file_name, is_folder}].
+    post = {
+        "zh_cn": {
+            "title": "报告",
+            "content": [[{"tag": "text", "text": "正文"}]],
+        },
+        "files": [
+            {"file_key": "file_a", "file_name": "report.pdf"},
+            {"file_key": "file_b"},
+            {"file_key": "dir_1", "file_name": "assets", "is_folder": True},
+        ],
+    }
+
+    t, r = flatten(PostContent(post=post))
+
+    assert "# 报告" in t
+    assert '正文' in t
+    assert '<file key="file_a" name="report.pdf"/>' in t
+    assert '<file key="file_b"/>' in t
+    assert '<folder key="dir_1" name="assets"/>' in t
+    # Files are downloadable resources; folders are tag-only.
+    assert [(x.type, x.file_key, x.file_name) for x in r] == [
+        ("file", "file_a", "report.pdf"),
+        ("file", "file_b", None),
+    ]
+
+
+def test_post_attachment_zone_ignores_empty_files():
+    post = {"zh_cn": {"content": [[{"tag": "text", "text": "hi"}]]}, "files": []}
+    t, r = flatten(PostContent(post=post))
+    assert "hi" in t
+    assert r == []
+
+
 def test_post_direct_document_shape_flattens_text_and_resources():
     post = {
         "title": "Direct",


### PR DESCRIPTION
## Summary

The rich-text **attachment zone** (top-level `files` array on a post message) was ignored by the channel post converter: only the locale document (`title`/`content`) was flattened and scanned for resources, so attachments attached to a rich-text message were invisible to channel consumers (agents/CLIs).

This PR makes the attachment zone visible and downloadable:

- **`lark_oapi/channel/normalize/converters/post.py`**
  - `_attachment_files()`: extract the top-level `files: [{file_key, file_name, is_folder}]` array
  - `_post_to_markdown()`: render attachment-zone entries as `<file key="..." name="..."/>` / `<folder key="..." name="..."/>` lines after the body, matching the standalone file/folder message converters
  - `_post_resources()`: surface attachment-zone **files** as `ResourceDescriptor(type="file")` so they are downloadable; **folders** stay tag-only (mirrors the standalone folder converter's `resources=[]`)
- **`lark_oapi/channel/tests/test_flatten.py`**: two new tests — rendering + resource extraction, and empty `files` array tolerance

## Wire shape

```
{
  "zh_cn": { "title": "...", "content": [...] },
  "files": [
    { "file_key": "file_a", "file_name": "report.pdf" },
    { "file_key": "dir_1", "file_name": "assets", "is_folder": true }
  ]
}
```

renders as:

```
# title
body...

<file key="file_a" name="report.pdf"/>
<folder key="dir_1" name="assets"/>
```

## Test

```
python3 -m pytest lark_oapi/channel/tests/test_flatten.py -q
# 17 passed
```